### PR TITLE
Public destructor should be virtual - C.35.

### DIFF
--- a/include/AnalyzerResults.h
+++ b/include/AnalyzerResults.h
@@ -14,7 +14,7 @@ class LOGICAPI Frame
   public:
     Frame();
     Frame( const Frame& frame );
-    ~Frame();
+    virtual ~Frame();
 
     S64 mStartingSampleInclusive;
     S64 mEndingSampleInclusive;


### PR DESCRIPTION
Making the destructor `virtual` would allow us to extend Frame and place what ever data we need in it.  It is also best practice according to the CppCoreGuidelines C.35, and was done for the `AnalyzerResults` class.

The work being done on `FrameV2` is similar in that it is intended to allow analyzers to place arbitrary data into `FrameV2`.